### PR TITLE
Ct crosswalk process during fetch

### DIFF
--- a/src/configs.py
+++ b/src/configs.py
@@ -32,7 +32,9 @@ STATE_FIPS_PATH = f"{PROCESSED_DIR}/state_geo_lkup"
 LAT_LON_PATH_NO_EXT = f"{PROCESSED_DIR}/lat-lon-area"
 
 CPDB_PATH = f"{AUTO_DOWNLOAD_DIR}/pdb2022bg.csv"
-CT_CW_PATH = f"{AUTO_DOWNLOAD_DIR}/2022blockcrosswalk.csv"
+CT_CW_RAW_PATH = f"{AUTO_DOWNLOAD_DIR}/2022blockcrosswalk.csv"
+CT_CW_PROC_PATH_NO_EXT = f"{PROCESSED_DIR}/CT_blockgroup_crosswalk_2020-2022"
+
 SHELL_DF_PATH = f"{AUTO_DOWNLOAD_DIR}/table_shells.csv"
 
 # zip codes

--- a/src/download_and_prep_data/fetch_misc_files.py
+++ b/src/download_and_prep_data/fetch_misc_files.py
@@ -1,6 +1,5 @@
 
 import sys
-# import os
 import pandas as pd
 
 sys.path.append("..")
@@ -19,22 +18,22 @@ from process_bg_tables.util import save_csv_and_dtypes
 REL_PATH = "../.."
 
 dataset_dict = {
-    # "cpdb": {
-    #     "name": "Census Planning Database",
-    #     "uri": "https://www2.census.gov/adrm/PDB/2022/pdb2022bg.csv",
-    #     "save_path": CPDB_PATH
-    # },
+    "cpdb": {
+        "name": "Census Planning Database",
+        "uri": "https://www2.census.gov/adrm/PDB/2022/pdb2022bg.csv",
+        "save_path": CPDB_PATH
+    },
     "ct_cw": {
         "name": "CT Crosswalk",
         "uri": "https://raw.githubusercontent.com/CT-Data-Collaborative/2022-block-crosswalk/main/2022blockcrosswalk.csv",
         "save_path": CT_CW_RAW_PATH,
     },
-    # "shells": {
-    #     "name": "Table Shells",
-    #     "uri": "https://www2.census.gov/programs-surveys/acs/summary_file/2022/table-based-SF/documentation/ACS20225YR_Table_Shells.txt",
-    #     "save_path": SHELL_DF_PATH,
-    #     "sep": "|"
-    # }
+    "shells": {
+        "name": "Table Shells",
+        "uri": "https://www2.census.gov/programs-surveys/acs/summary_file/2022/table-based-SF/documentation/ACS20225YR_Table_Shells.txt",
+        "save_path": SHELL_DF_PATH,
+        "sep": "|"
+    }
 }
 
 def download_geo_documentation(rel_path):
@@ -79,12 +78,11 @@ def prep_ct_crosswalk():
     cw_df_bg = cw_df[['bg_fips_2020', 'bg_fips_2022', 'zip5',
                       'county_fips_2020', 'ce_fips_2022', ]].drop_duplicates()
 
-    # return cw_df_bg
     save_csv_and_dtypes(cw_df_bg, CT_CW_PROC_PATH_NO_EXT, REL_PATH)
 
 
 def main(rel_path):
-    # download_geo_documentation(rel_path)
+    download_geo_documentation(rel_path)
     for dataset, ds_info in dataset_dict.items():
         _simple_get_csv(rel_path, **ds_info)
     prep_ct_crosswalk()

--- a/src/download_and_prep_data/fetch_misc_files.py
+++ b/src/download_and_prep_data/fetch_misc_files.py
@@ -1,12 +1,13 @@
 
 import sys
-import os
+# import os
 import pandas as pd
 
 sys.path.append("..")
 from configs import (
     CPDB_PATH,
-    CT_CW_PATH,
+    CT_CW_RAW_PATH,
+    CT_CW_PROC_PATH_NO_EXT,
     GEO_FILE_PATH_NO_EXT, 
     GEO_FILE_STUB,
     SHELL_DF_PATH,
@@ -16,6 +17,25 @@ from process_bg_tables.util import save_csv_and_dtypes
 
 # path of this file, relative to parent folder of project/repo
 REL_PATH = "../.."
+
+dataset_dict = {
+    # "cpdb": {
+    #     "name": "Census Planning Database",
+    #     "uri": "https://www2.census.gov/adrm/PDB/2022/pdb2022bg.csv",
+    #     "save_path": CPDB_PATH
+    # },
+    "ct_cw": {
+        "name": "CT Crosswalk",
+        "uri": "https://raw.githubusercontent.com/CT-Data-Collaborative/2022-block-crosswalk/main/2022blockcrosswalk.csv",
+        "save_path": CT_CW_RAW_PATH,
+    },
+    # "shells": {
+    #     "name": "Table Shells",
+    #     "uri": "https://www2.census.gov/programs-surveys/acs/summary_file/2022/table-based-SF/documentation/ACS20225YR_Table_Shells.txt",
+    #     "save_path": SHELL_DF_PATH,
+    #     "sep": "|"
+    # }
+}
 
 def download_geo_documentation(rel_path):
     print("Retrieving Geo Documentation")
@@ -34,30 +54,40 @@ def _simple_get_csv(rel_path, uri, save_path, name, sep=","):
     df.to_csv(f"{full_save_path}", index=False)
 
 
-dataset_dict = {
-    "cpdb": {
-        "name": "Census Planning Database",
-        "uri": "https://www2.census.gov/adrm/PDB/2022/pdb2022bg.csv",
-        "save_path": CPDB_PATH
-    },
-    "ct_cw": {
-        "name": "CT Crosswalk",
-        "uri": "https://raw.githubusercontent.com/CT-Data-Collaborative/2022-block-crosswalk/main/2022blockcrosswalk.csv",
-        "save_path": CT_CW_PATH,
-    },
-    "shells": {
-        "name": "Table Shells",
-        "uri": "https://www2.census.gov/programs-surveys/acs/summary_file/2022/table-based-SF/documentation/ACS20225YR_Table_Shells.txt",
-        "save_path": SHELL_DF_PATH,
-        "sep": "|"
-    }
+def prep_ct_crosswalk():
+    """Load and process data that cross-walks old FIPS to new FIPS for CT entities.
+    """
+    print("Processing CT Crosswalk file")
+    cw_df = pd.read_csv(f"{REL_PATH}/{CT_CW_RAW_PATH}", dtype="object")
 
-}
+    # need to 0-pad some numbers:
+    pad_dict = {
+        'block_fips_2020': 15,
+        'block_fips_2022': 15,
+        'county_fips_2020': 5,
+        'ce_fips_2022': 5,
+        'zip5': 5
+    }
+    for col, pad in pad_dict.items():
+        cw_df[col] = cw_df[col].apply(lambda x: x.zfill(pad))
+        
+    # data is at block level; we want blockgroup
+    cw_df['bg_fips_2020'] = cw_df['block_fips_2020'].str[:-3]
+    cw_df['bg_fips_2022'] = cw_df['block_fips_2022'].str[:-3]
+    ## Note: I confirmed that there is only 1 zip or county per bg,
+    ## so we don't need to use % land area for mapping
+    cw_df_bg = cw_df[['bg_fips_2020', 'bg_fips_2022', 'zip5',
+                      'county_fips_2020', 'ce_fips_2022', ]].drop_duplicates()
+
+    # return cw_df_bg
+    save_csv_and_dtypes(cw_df_bg, CT_CW_PROC_PATH_NO_EXT, REL_PATH)
+
 
 def main(rel_path):
-    download_geo_documentation(rel_path)
+    # download_geo_documentation(rel_path)
     for dataset, ds_info in dataset_dict.items():
         _simple_get_csv(rel_path, **ds_info)
+    prep_ct_crosswalk()
 
 
 if __name__ == "__main__":

--- a/src/generate_blockgroup_dataset.py
+++ b/src/generate_blockgroup_dataset.py
@@ -25,14 +25,12 @@ from process_bg_tables.util import (
 )
 from download_and_prep_data import process_zip_data
 from configs import (
-    ACS_BG_FILENAME, 
     AREA_COL,
     BG_TABLE_KEY_COL,
     BG_ZIP_DEDUP_PATH_NO_EXT,
     CPDB_PATH, 
     CT_CW_PROC_PATH_NO_EXT,
     CT_MSA_CW_DICT,
-    FINAL_OUTPUT_DIR,
     LAT_LON_PATH_NO_EXT,
     MEDIAN_AGE_COL,
     MIL_GEO_IND_PATH_NO_EXT,
@@ -397,6 +395,5 @@ if __name__ == "__main__":
         final_df = msa_merge_df.drop(columns=['GEOID'])
 
         print("Saving Final data")
-        # save_csv_and_dtypes(final_df, f"{FINAL_OUTPUT_DIR}/{ACS_BG_FILENAME}", REL_PATH)
         save_final_data(final_df, REL_PATH)
         print("Done!")

--- a/src/generate_blockgroup_dataset.py
+++ b/src/generate_blockgroup_dataset.py
@@ -30,7 +30,7 @@ from configs import (
     BG_TABLE_KEY_COL,
     BG_ZIP_DEDUP_PATH_NO_EXT,
     CPDB_PATH, 
-    CT_CW_PATH,
+    CT_CW_PROC_PATH_NO_EXT,
     CT_MSA_CW_DICT,
     FINAL_OUTPUT_DIR,
     LAT_LON_PATH_NO_EXT,
@@ -122,30 +122,30 @@ def load_planning_db():
     return pdb_df
 
 
-def get_ct_crosswalk():
-    """Load and process data that cross-walks old FIPS to new FIPS for CT entities.
-    """
-    cw_df = pd.read_csv(f"{REL_PATH}/{CT_CW_PATH}", dtype="object")
+# def get_ct_crosswalk():
+#     """Load and process data that cross-walks old FIPS to new FIPS for CT entities.
+#     """
+#     cw_df = pd.read_csv(f"{REL_PATH}/{CT_CW_PATH}", dtype="object")
 
-    # need to 0-pad some numbers:
-    pad_dict = {
-        'block_fips_2020': 15,
-        'block_fips_2022': 15,
-        'county_fips_2020': 5,
-        'ce_fips_2022': 5,
-        'zip5': 5
-    }
-    for col, pad in pad_dict.items():
-        cw_df[col] = cw_df[col].apply(lambda x: x.zfill(pad))
+#     # need to 0-pad some numbers:
+#     pad_dict = {
+#         'block_fips_2020': 15,
+#         'block_fips_2022': 15,
+#         'county_fips_2020': 5,
+#         'ce_fips_2022': 5,
+#         'zip5': 5
+#     }
+#     for col, pad in pad_dict.items():
+#         cw_df[col] = cw_df[col].apply(lambda x: x.zfill(pad))
         
-    # data is at block level; we want blockgroup
-    cw_df['bg_fips_2020'] = cw_df['block_fips_2020'].str[:-3]
-    cw_df['bg_fips_2022'] = cw_df['block_fips_2022'].str[:-3]
-    ## confirmed that there is only 1 zip or county per bg
-    cw_df_bg = cw_df[['bg_fips_2020', 'bg_fips_2022', 'zip5',
-                      'county_fips_2020', 'ce_fips_2022', ]].drop_duplicates()
+#     # data is at block level; we want blockgroup
+#     cw_df['bg_fips_2020'] = cw_df['block_fips_2020'].str[:-3]
+#     cw_df['bg_fips_2022'] = cw_df['block_fips_2022'].str[:-3]
+#     ## confirmed that there is only 1 zip or county per bg
+#     cw_df_bg = cw_df[['bg_fips_2020', 'bg_fips_2022', 'zip5',
+#                       'county_fips_2020', 'ce_fips_2022', ]].drop_duplicates()
 
-    return cw_df_bg
+#     return cw_df_bg
 
 
 def derive_planning_db_attrs(pdb_df: pd.DataFrame, 
@@ -260,8 +260,9 @@ if __name__ == "__main__":
         pdb_df = load_planning_db()
 
         ## This function returns old bg --> new bg crosswalk, plus zip and old & new county fips
-        ct_cw_df = get_ct_crosswalk()
-
+        # ct_cw_df = get_ct_crosswalk()
+        ct_cw_df = load_csv_with_dtypes(CT_CW_PROC_PATH_NO_EXT, REL_PATH)
+        
         # merge with Planning Database
         pdb_cw_df = pdb_df.merge(ct_cw_df, how='left',
                                  left_on='GIDBG', right_on='bg_fips_2020')


### PR DESCRIPTION
Process CT Crosswalk in fetch script, instead of `generate_blockgroup_dataset.py`, so we have a nice lookup file at the blockgroup level for CT.

Also clean up some code from the dtypes csv work.